### PR TITLE
Bugfix: deletion of first space in a cell

### DIFF
--- a/static/js/datatables.js
+++ b/static/js/datatables.js
@@ -616,7 +616,7 @@ var Datatables = function () {
     if (numOfRows != 0) {
       for (var i = 0; i < tblRows.length; i++) {
         tblRows[i] = " ";
-      }
+              }
     }
     payload = [tblRows];
     if (table) {
@@ -796,10 +796,10 @@ var Datatables = function () {
       while (rep.selStart[0] < rep.lines.length() && rep.lines.atIndex(rep.selStart[0]).text.indexOf('data-tables') != -1) { //count num of rows above current pos
         var cellPos = this.getTdInfo(payload, currTd).cellEndOffset;
         var newText = '" ",';
-        if (currTd == payload[0].length - 1) { //add to the most right
+                if (currTd == payload[0].length - 1) { //add to the most right
           rep.selStart[1] = rep.selEnd[1] = cellPos - this.vars.OVERHEAD_LEN_ROW_END + 1;
           newText = '," "';
-        } else if (currTd == -1) { //add to most left
+                  } else if (currTd == -1) { //add to most left
           rep.selStart[1] = rep.selEnd[1] = this.vars.OVERHEAD_LEN_PRE - 1;
         } else {
           rep.selStart[1] = rep.selEnd[1] = cellPos - 1;
@@ -879,7 +879,7 @@ var Datatables = function () {
     if (numOfRows != 0) {
       for (var i = 0; i < tblRows.length; i++) {
         tblRows[i] = " ";
-      }
+              }
     }
     payload = [tblRows];
     if (table) {
@@ -944,8 +944,10 @@ var Datatables = function () {
       var currCarretPos = rep.selStart[1];
       if (currLineText.substring(currCarretPos - 1, currCarretPos + 2) == '","') return false;
       else if (currLineText.substring(currCarretPos - 2, currCarretPos + 1) == '","') return false;
+      // never delete the first space in a cell
+      else if (currLineText.substring(currCarretPos - 2, currCarretPos) == '" ') return false;
       switch (keyCode) {
-        case this.vars.JS_KEY_CODE_BS:
+        case this.vars.JS_KEY_CODE_BS:  
           if (cellEntryLen != 0 && cellEntryLen > (currTdInfo.leftOverTdTxtLen - this.vars.OVERHEAD_LEN_MID)) {
             isDeleteAccepted = true;
           }
@@ -1074,7 +1076,12 @@ var Datatables = function () {
                 editorInfo.ace_performDocumentReplaceCharRange(deleteBackTo, docChar, '');
               } else {
                 var returnKeyWitinTblOffset = 0;
-                if (lineText.substring(col - 5, col) == '/r/n ') {
+                // if there is a newline with two more spaces in front of it,
+                // then delete ' /r/n '. the first space must be left, 
+                // because never delete the first space in a cell
+                if (lineText.substring(col - 7, col) == '  /r/n ') {
+                  returnKeyWitinTblOffset = 5;
+                } else if (lineText.substring(col - 5, col) == '/r/n ') {
                   returnKeyWitinTblOffset = 4;
                 }
                 // normal or table return key delete

--- a/static/js/datatables.js
+++ b/static/js/datatables.js
@@ -616,7 +616,7 @@ var Datatables = function () {
     if (numOfRows != 0) {
       for (var i = 0; i < tblRows.length; i++) {
         tblRows[i] = " ";
-              }
+      }
     }
     payload = [tblRows];
     if (table) {
@@ -796,10 +796,10 @@ var Datatables = function () {
       while (rep.selStart[0] < rep.lines.length() && rep.lines.atIndex(rep.selStart[0]).text.indexOf('data-tables') != -1) { //count num of rows above current pos
         var cellPos = this.getTdInfo(payload, currTd).cellEndOffset;
         var newText = '" ",';
-                if (currTd == payload[0].length - 1) { //add to the most right
+        if (currTd == payload[0].length - 1) { //add to the most right
           rep.selStart[1] = rep.selEnd[1] = cellPos - this.vars.OVERHEAD_LEN_ROW_END + 1;
           newText = '," "';
-                  } else if (currTd == -1) { //add to most left
+        } else if (currTd == -1) { //add to most left
           rep.selStart[1] = rep.selEnd[1] = this.vars.OVERHEAD_LEN_PRE - 1;
         } else {
           rep.selStart[1] = rep.selEnd[1] = cellPos - 1;
@@ -879,7 +879,7 @@ var Datatables = function () {
     if (numOfRows != 0) {
       for (var i = 0; i < tblRows.length; i++) {
         tblRows[i] = " ";
-              }
+      }
     }
     payload = [tblRows];
     if (table) {
@@ -947,7 +947,7 @@ var Datatables = function () {
       // never delete the first space in a cell
       else if (currLineText.substring(currCarretPos - 2, currCarretPos) == '" ') return false;
       switch (keyCode) {
-        case this.vars.JS_KEY_CODE_BS:  
+        case this.vars.JS_KEY_CODE_BS:
           if (cellEntryLen != 0 && cellEntryLen > (currTdInfo.leftOverTdTxtLen - this.vars.OVERHEAD_LEN_MID)) {
             isDeleteAccepted = true;
           }


### PR DESCRIPTION
hi Rakotomalala,

there is a bug in the code: when you delete the first space in a cell, then all cells behind this cell behave not normal. if you put your mouse cursor into on of this cells, the mouse cursor runs automatically to the end. if you try to delete something from this cells, then the hole row gets deleted. i captured the behavior: [bug_deletion_of_first_space_in_cell.webm](https://github.com/mamylinx/ep_tableau/assets/34709875/a68cb79a-1bc2-4998-b6c3-ecde7dd91657)
=> i fixed it with one more condition in line 948 and added a comment.

additionally, i fixed a minor bug too: enter a couple of newlines in a cell and later delete them again, begin on the bottom. then you need two backspaces for every line, because of an additionally space. 
=> i fixed it with one more condition in line 1082 and added a comment. now its just one backspace for every line.